### PR TITLE
Test: Paid down TDD tech debt for v1.33.0-1.36.0 (Closes #151)

### DIFF
--- a/tests/test_aim_doctor.py
+++ b/tests/test_aim_doctor.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+# Ensure scripts dir is in path
+current_dir = os.path.dirname(os.path.abspath(__file__))
+aim_root = os.path.dirname(current_dir)
+scripts_dir = os.path.join(aim_root, "scripts")
+if scripts_dir not in sys.path:
+    sys.path.append(scripts_dir)
+
+import aim_doctor
+
+class TestAimDoctor(unittest.TestCase):
+    
+    @patch("aim_doctor.subprocess.run")
+    def test_check_command_success(self, mock_run):
+        # Should return True if subprocess succeeds
+        result = aim_doctor.check_command(["git", "--version"], "Git")
+        self.assertTrue(result)
+        mock_run.assert_called_once()
+        
+    @patch("aim_doctor.subprocess.run")
+    def test_check_command_failure(self, mock_run):
+        import subprocess
+        # Should return False if subprocess fails
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+        result = aim_doctor.check_command(["git", "--version"], "Git")
+        self.assertFalse(result)
+
+    def test_check_python_version(self):
+        # We are running this in python 3.10+, so this should be True natively
+        # But we can mock sys.version_info to test failure
+        import collections
+        VersionInfo = collections.namedtuple('VersionInfo', ['major', 'minor', 'micro', 'releaselevel', 'serial'])
+        
+        with patch("sys.version_info", VersionInfo(3, 9, 0, 'final', 0)):
+            self.assertFalse(aim_doctor.check_python_version())
+        
+        with patch("sys.version_info", VersionInfo(3, 11, 0, 'final', 0)):
+            self.assertTrue(aim_doctor.check_python_version())
+
+    @patch("aim_doctor.sqlite3.connect")
+    def test_check_sqlite_success(self, mock_connect):
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = ("3.45.1",)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connect.return_value = mock_conn
+        
+        self.assertTrue(aim_doctor.check_sqlite())
+
+    @patch("aim_doctor.sqlite3.connect")
+    def test_check_sqlite_failure(self, mock_connect):
+        mock_connect.side_effect = Exception("SQLite Error")
+        self.assertFalse(aim_doctor.check_sqlite())
+
+    @patch("sys.platform", "linux")
+    def test_check_keyring_deps_linux_missing(self):
+        # Test when dbus is missing on linux
+        with patch.dict("sys.modules", {"dbus": None}):
+            # Should still return True (it just warns)
+            self.assertTrue(aim_doctor.check_keyring_deps())
+
+    @patch("sys.platform", "darwin")
+    def test_check_keyring_deps_mac(self):
+        self.assertTrue(aim_doctor.check_keyring_deps())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_context_injector.py
+++ b/tests/test_context_injector.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+import tempfile
+import shutil
+
+# Ensure hooks dir is in path
+current_dir = os.path.dirname(os.path.abspath(__file__))
+aim_root = os.path.dirname(current_dir)
+hooks_dir = os.path.join(aim_root, "hooks")
+if hooks_dir not in sys.path:
+    sys.path.append(hooks_dir)
+
+# We have to mock sys.stdin before importing context_injector because it reads sys.stdin on import
+import io
+sys.stdin = io.StringIO("{}")
+
+import context_injector
+
+class TestContextInjector(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.continuity_dir = os.path.join(self.test_dir, "continuity")
+        self.core_dir = os.path.join(self.test_dir, "core")
+        os.makedirs(self.continuity_dir)
+        os.makedirs(self.core_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    @patch("context_injector.CONFIG")
+    def test_get_pulse_and_tail_returns_all_files(self, mock_config):
+        mock_config.__getitem__.return_value = {
+            'continuity_dir': self.continuity_dir,
+            'core_dir': self.core_dir
+        }
+        mock_config.get.return_value = {
+            'continuity_dir': self.continuity_dir,
+            'core_dir': self.core_dir
+        }
+        
+        # Create the fake files
+        pulse_path = os.path.join(self.continuity_dir, "CURRENT_PULSE.md")
+        tail_path = os.path.join(self.continuity_dir, "FALLBACK_TAIL.md")
+        core_mem_path = os.path.join(self.continuity_dir, "CORE_MEMORY.md")
+        anchor_path = os.path.join(self.core_dir, "ANCHOR.md")
+        
+        with open(pulse_path, 'w') as f: f.write("PULSE DATA")
+        with open(tail_path, 'w') as f: f.write("TAIL DATA")
+        with open(core_mem_path, 'w') as f: f.write("CORE MEMORY DATA")
+        with open(anchor_path, 'w') as f: f.write("ANCHOR DATA")
+        
+        pulse, tail, anchor, core_mem = context_injector.get_pulse_and_tail()
+        
+        self.assertEqual(pulse, "PULSE DATA")
+        self.assertEqual(tail, "TAIL DATA")
+        self.assertEqual(anchor, "ANCHOR DATA")
+        self.assertEqual(core_mem, "CORE MEMORY DATA")
+
+    @patch("context_injector.CONFIG")
+    def test_get_pulse_and_tail_handles_missing_files(self, mock_config):
+        mock_config.__getitem__.return_value = {
+            'continuity_dir': self.continuity_dir,
+            'core_dir': self.core_dir
+        }
+        mock_config.get.return_value = {
+            'continuity_dir': self.continuity_dir,
+            'core_dir': self.core_dir
+        }
+        
+        # We don't create any files. They should return None without crashing
+        pulse, tail, anchor, core_mem = context_injector.get_pulse_and_tail()
+        
+        self.assertIsNone(pulse)
+        self.assertIsNone(tail)
+        self.assertIsNone(anchor)
+        self.assertIsNone(core_mem)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_datajack.py
+++ b/tests/test_datajack.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+import tempfile
+import shutil
+import json
+import hashlib
+import zipfile
+
+# Ensure aim_root is in path
+current_dir = os.path.dirname(os.path.abspath(__file__))
+aim_root = os.path.dirname(current_dir)
+if aim_root not in sys.path:
+    sys.path.append(aim_root)
+    
+src_dir = os.path.join(aim_root, "src")
+if src_dir not in sys.path:
+    sys.path.append(src_dir)
+
+# Now we can safely import the plugins
+from plugins.datajack import aim_exchange
+
+class TestDataJackChecksums(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.cartridge_path = os.path.join(self.test_dir, "test.engram")
+        self.import_dir = os.path.join(self.test_dir, "archive", "tmp_engram_import")
+        
+        # Override paths to avoid nuking real directories
+        aim_exchange.AIM_ROOT = self.test_dir
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    @patch("plugins.datajack.aim_exchange.ForensicDB")
+    @patch("builtins.input", return_value="y")
+    def test_import_cartridge_checksum_valid(self, mock_input, mock_db):
+        """Tests that a cartridge with a valid SHA256 payload_hash successfully imports."""
+        
+        # Create a fake cartridge structure
+        os.makedirs(os.path.join(self.test_dir, "chunks"))
+        jsonl_path = os.path.join(self.test_dir, "chunks", "session1.jsonl")
+        
+        # Write valid JSONL content
+        content = json.dumps({"session_id": "session1", "filename": "test.md", "mtime": 100}) + "\n"
+        content += json.dumps({"content": "test data", "type": "knowledge", "embedding": [0.1, 0.2], "metadata": {}}) + "\n"
+        
+        with open(jsonl_path, 'w') as f:
+            f.write(content)
+            
+        # Calculate the real hash of this content
+        hasher = hashlib.sha256()
+        hasher.update(content.encode('utf-8'))
+        valid_hash = hasher.hexdigest()
+        
+        # Write the metadata.json
+        metadata = {
+            "keyword": "test",
+            "payload_hash": valid_hash
+        }
+        with open(os.path.join(self.test_dir, "metadata.json"), 'w') as f:
+            json.dump(metadata, f)
+            
+        # Zip it into an engram
+        with zipfile.ZipFile(self.cartridge_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.write(os.path.join(self.test_dir, "metadata.json"), "metadata.json")
+            zf.write(jsonl_path, "chunks/session1.jsonl")
+            
+        # Run import
+        aim_exchange.import_cartridge(self.cartridge_path)
+        
+        # Assert the DB was called to add the fragments (meaning it passed the checksum)
+        mock_instance = mock_db.return_value
+        mock_instance.add_session.assert_called_once()
+        mock_instance.add_fragments.assert_called_once()
+        mock_instance.rebuild_fts.assert_called_once()
+
+    @patch("plugins.datajack.aim_exchange.ForensicDB")
+    @patch("builtins.input", return_value="y")
+    def test_import_cartridge_checksum_invalid(self, mock_input, mock_db):
+        """Tests that a cartridge with an invalid SHA256 payload_hash aborts before touching the DB."""
+        
+        # Create a fake cartridge structure
+        os.makedirs(os.path.join(self.test_dir, "chunks"))
+        jsonl_path = os.path.join(self.test_dir, "chunks", "session1.jsonl")
+        
+        # Write JSONL content
+        content = json.dumps({"session_id": "session1", "filename": "test.md", "mtime": 100}) + "\n"
+        with open(jsonl_path, 'w') as f:
+            f.write(content)
+            
+        # Write metadata.json with a COMPLETELY WRONG hash
+        metadata = {
+            "keyword": "test",
+            "payload_hash": "bad_hash_12345"
+        }
+        with open(os.path.join(self.test_dir, "metadata.json"), 'w') as f:
+            json.dump(metadata, f)
+            
+        # Zip it
+        with zipfile.ZipFile(self.cartridge_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            zf.write(os.path.join(self.test_dir, "metadata.json"), "metadata.json")
+            zf.write(jsonl_path, "chunks/session1.jsonl")
+            
+        # Run import
+        aim_exchange.import_cartridge(self.cartridge_path)
+        
+        # Assert the DB was NEVER instantiated or called because the checksum failed
+        mock_db.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added unit tests for `aim_doctor.py`, the `context_injector` onboarding sequence, and the DataJack SHA-256 Checksum validation to restore empirical certainty to the A.I.M. architecture.